### PR TITLE
new module and new repo bits and bobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: "Release new version of the module"
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  autoformat:
+    uses: ./.github/workflows/tf_formatting.yml
+  
+  # First, check if there is a RELEASE.md file in the root of the repository.
+  # If not, no release will be created and subsequent steps and jobs will be skipped.
+  check-for-release-file:
+    runs-on: ubuntu-latest
+    outputs:
+      has-release: ${{ steps.check-for-release-file.outputs.has-release }}
+    needs: autoformat
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for RELEASE.md file
+        id: check-for-release-file
+        run: |
+          if [ ! -f ./RELEASE.md ]; then
+            echo "has-release=false" >> $GITHUB_OUTPUT
+            echo "No release detected. Exiting."
+            exit 0
+          fi
+          echo "has-release=true" >> $GITHUB_OUTPUT
+
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      new-version: ${{ steps.create-release.outputs.new-version }}
+    needs: check-for-release-file
+    if: needs.check-for-release-file.outputs.has-release == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Update CHANGELOG.md and version
+        id: create-release
+        run: |
+          git fetch --tags
+          LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+          python3 gha_scripts/create_release.py ${LATEST_TAG} $(pwd)
+          
+          VERSION_TAG="$(cat CHANGELOG.md | grep -m1 -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+')"
+          echo "new-version=${VERSION_TAG:1}" >> $GITHUB_OUTPUT          
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 129326 # App ID of the Wellcome Collection app
+          private-key: ${{ secrets.WELLCOME_COLLECTION_APP_PRIVATE_KEY }}
+        
+      # We need to give the GitHub action full repo privileges so that it can push the release directly into main
+      - name: Configure git
+        run: |
+          git config --global user.name "GitHub on behalf of Wellcome Collection"
+          git config --global user.email "wellcomedigitalplatform@wellcome.ac.uk"
+          git remote set-url origin https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository }}.git
+
+      - name: Commit and push changes
+        run: |
+          git checkout main
+          git pull
+          git add CHANGELOG.md
+          git rm RELEASE.md
+          
+          NEW_TAG="v${{ steps.create-release.outputs.new-version }}"
+          git commit -m "$(printf "Bump version to ${NEW_TAG}\n\n[skip ci]")"
+          git tag ${NEW_TAG}
+
+          git push origin main
+          git push origin --tags    

--- a/.github/workflows/tf_formatting.yml
+++ b/.github/workflows/tf_formatting.yml
@@ -1,0 +1,39 @@
+# Runs auto-formatting script on push to any branch
+name: "Run terraform formatting"
+
+on:
+  push:
+    branches-ignore:
+      - main
+  workflow_call:
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  autoformat:
+    name: autoformat
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v4
+
+      - name: terraform format (recursive)
+        uses: dflook/terraform-fmt@v1
+
+      - name: Check for formatting changes
+        id: check_formatting_changes
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+              echo "changes=true" >> "$GITHUB_OUTPUT"; 
+          fi
+
+      - name: Commit and push formatting changes
+        if: steps.check_formatting_changes.outputs.changes == 'true'
+        run: |
+          git config user.name "Github on behalf of Wellcome Collection"
+          git config user.email "wellcomedigitalplatform@wellcome.ac.uk"
+          git commit -am "Apply auto-formatting rules"
+          git push
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.84.0"
+  hashes = [
+    "h1:OJ53RNte7HLHSMxSkzu1S6H8sC0T8qnCAOcNLjjtMpc=",
+    "zh:078f77438aba6ec8bf9154b7d223e5c71c48d805d6cd3bcf9db0cc1e82668ac3",
+    "zh:1f6591ff96be00501e71b792ed3a5a14b21ff03afec9a1c4a3fd9300e6e5b674",
+    "zh:2ab694e022e81dd74485351c5836148a842ed71cf640664c9d871cb517b09602",
+    "zh:33c8ccb6e3dc496e828a7572dd981366c6271075c1189f249b9b5236361d7eff",
+    "zh:6f31068ebad1d627e421c72ccdaafe678c53600ca73714e977bf45ff43ae5d17",
+    "zh:7488623dccfb639347cae66f9001d39cf06b92e8081975235a1ac3a0ac3f44aa",
+    "zh:7f042b78b9690a8725c95b91a70fc8e264011b836605bcc342ac297b9ea3937d",
+    "zh:88b56ac6c7209dc0a775b79975a371918f3aed8f015c37d5899f31deff37c61a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1979ba840d704af0932f8de5f541cbb4caa9b6bbd25ed552a24e6772175ba07",
+    "zh:b058c0533dae580e69d1adbc1f69e6a80632374abfc10e8634d06187a108e87b",
+    "zh:c88610af9cf957f8dcf4382e0c9ca566ef10e3290f5de01d4d90b2d81b078aa8",
+    "zh:e9562c055a2247d0c287772b55abef468c79f8d66a74780fe1c5e5dae1a284a9",
+    "zh:f7a7c71d28441d925a25c08c4485c015b2d9f0338bc9707443e91ff8e161d3d9",
+    "zh:fee533e81976d0900aa6fa443dc54ef171cbd901847f28a6e8edb1d161fa6fde",
+  ]
+}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+*   @wellcomecollection/digital-platform
+    

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Wellcome Collection
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: major  
+Initial release.  
+This is based on the version of the github_repo_role module in [aws-account-infrastructure@f0f948f](https://github.com/wellcomecollection/aws-account-infrastructure/commit/f0f948f07ae386cde9ec115e50482dcda9500e59).

--- a/gha_scripts/create_release.py
+++ b/gha_scripts/create_release.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+import datetime as dt
+import os
+import re
+import sys
+
+RELEASE_TYPE = re.compile(r"^RELEASE_TYPE: +(major|minor|patch)")
+VALID_RELEASE_TYPES = ('major', 'minor', 'patch')
+
+CHANGELOG_HEADER = re.compile(r"^## v\d+\.\d+\.\d+ - \d\d\d\d-\d\d-\d\d$")
+
+
+def get_new_version_tag(latest_version: str, release_type: str):
+    version_info = [int(i) for i in latest_version.lstrip('v').split('.')]
+
+    bump = VALID_RELEASE_TYPES.index(release_type)
+    version_info[bump] += 1
+    for i in range(bump + 1, len(version_info)):
+        version_info[i] = 0
+    return 'v' + '.'.join(map(str, version_info))
+
+
+def _get_changelog_version_heading(new_version_tag: str):
+    date = dt.datetime.utcnow().strftime('%Y-%m-%d')
+    return f'## {new_version_tag} - {date}'
+
+
+def update_changelog(release_contents: str, new_version_tag: str):
+    with open(CHANGELOG_FILE) as f:
+        changelog_contents = f.read()
+
+    assert '\r' not in changelog_contents
+    lines = changelog_contents.split('\n')
+    assert changelog_contents == '\n'.join(lines)
+
+    for i, line in enumerate(lines):
+        if CHANGELOG_HEADER.match(line):
+            beginning = '\n'.join(lines[:i])
+            rest = '\n'.join(lines[i:])
+            assert '\n'.join((beginning, rest)) == changelog_contents
+            break
+
+    new_version_heading = _get_changelog_version_heading(new_version_tag)
+
+    new_changelog_parts = [
+        beginning.strip(),
+        new_version_heading,
+        release_contents,
+        rest
+    ]
+
+    with open(CHANGELOG_FILE, 'w') as f:
+        f.write('\n\n'.join(new_changelog_parts))
+
+def parse_release_file():
+    """
+    Parses the release file, returning a tuple (release_type, release_contents)
+    """
+    with open(RELEASE_FILE) as i:
+        release_contents = i.read()
+
+    release_lines = release_contents.split('\n')
+
+    m = RELEASE_TYPE.match(release_lines[0])
+    if m is not None:
+        release_type = m.group(1)
+        if release_type not in VALID_RELEASE_TYPES:
+            print('Unrecognised release type %r' % (release_type,))
+            sys.exit(1)
+        del release_lines[0]
+        release_contents = '\n'.join(release_lines).strip()
+    else:
+        print(
+            'RELEASE.md does not start by specifying release type. The first '
+            'line of the file should be RELEASE_TYPE: followed by one of '
+            'major, minor, or patch, to specify the type of release that '
+            'this is (i.e. which version number to increment). Instead the '
+            'first line was %r' % (release_lines[0],)
+        )
+        sys.exit(1)
+
+    return release_type, release_contents
+
+
+def create_release():
+    latest_version_tag = sys.argv[1]
+
+    release_type, release_contents = parse_release_file()
+    new_version_tag = get_new_version_tag(latest_version_tag, release_type)
+
+    update_changelog(release_contents, new_version_tag)
+
+if __name__ == '__main__':
+    ROOT = sys.argv[2]
+    CHANGELOG_FILE = os.path.join(ROOT, 'CHANGELOG.md')
+    RELEASE_FILE = os.path.join(ROOT, 'RELEASE.md')
+
+    create_release()

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,43 @@
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test = "StringLike"
+      values = [
+        "repo:%{if length(regexall(":+", var.github_repository)) > 0}${var.github_repository}%{else}${var.github_repository}:*%{endif}"
+      ]
+      variable = "token.actions.githubusercontent.com:sub"
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = ["sts.amazonaws.com"]
+      variable = "token.actions.githubusercontent.com:aud"
+    }
+
+    principals {
+      identifiers = [var.github_oidc_provider_arn]
+      type        = "Federated"
+    }
+  }
+
+  version = "2012-10-17"
+}
+
+resource "aws_iam_role" "github_actions" {
+  name_prefix          = "gha-${var.role_name}-"
+  description          = "Inital role assumed by the GitHub OIDC provider"
+  max_session_duration = 3600 // Minimum session duration in seconds, 1 hour
+  assume_role_policy   = data.aws_iam_policy_document.github_actions_assume_role.json
+}
+
+resource "aws_iam_role_policy" "github_actions_assume_role_policy" {
+  policy = var.policy_document
+  role   = aws_iam_role.github_actions.name
+}
+
+output "role_arn" {
+  value = aws_iam_role.github_actions.arn
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,7 +1,0 @@
-terraform {
-  required_providers {
-    aws = {
-      source = "hashicorp/aws"
-    }
-  }
-}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,16 @@
+// The repositories that are allowed to assume the github_actions_assume_role
+variable "github_repository" {
+  type = string
+}
+
+variable "github_oidc_provider_arn" {
+  type = string
+}
+
+variable "role_name" {
+  type = string
+}
+
+variable "policy_document" {
+  type = string
+}


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/platform/issues/5887
A module to consistently create iam roles for Github actions runners to affect AWS resources 

## How to test

Used it locally to plan resources that allow the `catalogue-api` to read from `vhs-sourcedata-miro` DDB table

```
Terraform will perform the following actions:

  # module.new_gha_role.aws_iam_role.github_actions will be created
  + resource "aws_iam_role" "github_actions" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRoleWithWebIdentity"
                      + Condition = {
                          + StringEquals = {
                              + "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
                            }
                          + StringLike   = {
                              + "token.actions.githubusercontent.com:sub" = "repo:wellcomecollection/catalogue-api:*"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Federated = "arn:aws:iam::130871440101:oidc-provider/token.actions.githubusercontent.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + description           = "Inital role assumed by the GitHub OIDC provider"
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = (known after apply)
      + name_prefix           = "gha-new_gha_role-"
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy (known after apply)
    }

  # module.new_gha_role.aws_iam_role_policy.github_actions_assume_role_policy will be created
  + resource "aws_iam_role_policy" "github_actions_assume_role_policy" {
      + id          = (known after apply)
      + name        = (known after apply)
      + name_prefix = (known after apply)
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "dynamodb:Scan",
                          + "dynamodb:Query",
                          + "dynamodb:GetItem",
                          + "dynamodb:ConditionCheckItem",
                          + "dynamodb:BatchGetItem",
                        ]
                      + Effect   = "Allow"
                      + Resource = "arn:aws:dynamodb:eu-west-1:760097843905:table/vhs-sourcedata-miro"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + role        = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```

## How can we measure success?

We can easily create oidc-backed iam role for repositories. Github runners can affect the AWS resources they need.

## Have we considered potential risks?

This is designed to assign specific, limited permissions to one repository for one AWS account. 

